### PR TITLE
Fix wrong position when using percentage width/height smaller than minWidth/Height

### DIFF
--- a/layx.js
+++ b/layx.js
@@ -263,11 +263,11 @@
             _minHeight = Utils.compileLayxWidthOrHeight("height", config.minHeight, that.defaults.minHeight);
             _width = Utils.compileLayxWidthOrHeight("width", config.width, that.defaults.width);
             _height = Utils.compileLayxWidthOrHeight("height", config.height, that.defaults.height);
+            _width = Math.max(_width, _minWidth);
+            _height = Math.max(_height, _minHeight);
             var _position = Utils.compileLayxPosition(_width, _height, config.position);
             _top = _position.top;
             _left = _position.left;
-            _width = Math.max(_width, _minWidth);
-            _height = Math.max(_height, _minHeight);
             _top = Math.max(_top, 0);
             _top = Math.min(win.innerHeight - 15, _top);
             _left = Math.max(_left, -(_width - 15));


### PR DESCRIPTION
For example, if my device is `360(w)x640(h)` and my LayX config is

```javascript
{
        width: '40%',
        minWidth: 360,
        height: 175,
        minHeight: 175,
}
```
The `40%` width is actually `360 * 0.4 = 144` which is smaller than `minWidth = 360`.
So the final `_width` should be `360`. And then use `_width = 360` to do `_position` calculation.

---

Before fix:

![snipaste_2018-09-18_21-37-03](https://user-images.githubusercontent.com/6594915/45691676-a05b8200-bb8b-11e8-9158-7925c63cc7d7.png)


After fix:

![snipaste_2018-09-18_21-36-37](https://user-images.githubusercontent.com/6594915/45691683-a2bddc00-bb8b-11e8-8852-07aba0f8d4c7.png)
