### PR TITLE
Fix ReferenceError: iframeTitle is not defined

### DIFF
--- a/layx.js
+++ b/layx.js
@@ -1129,6 +1129,7 @@
                         iframe.setAttribute("data-focus", "true");
                     }
                 }
+                var iframeTitle = config.title;
                 if (type === "group") {
                     if (frameConfig.useFrameTitle === true) {
                         iframeTitle = iframe.contentWindow.document.querySelector("title").innerText;


### PR DESCRIPTION
I am converting a normal website project to use Webpack recently. After packing up Layx and creating a iframe with `useFrameTitle: true,`, I found that there is no title but it worked before I use Webpack.

![snipaste_2018-09-22_04-30-10](https://user-images.githubusercontent.com/6594915/45904863-e3825300-be20-11e8-95c6-f0de294d0731.png)

The `iframeTitle` variable here is not declared before, hence this PR.